### PR TITLE
Add new social sharing options

### DIFF
--- a/src/components/About/Blog/index.js
+++ b/src/components/About/Blog/index.js
@@ -11,6 +11,8 @@ import {
   TwitterShareButton,
   FacebookIcon,
   TwitterIcon,
+  LinkedinShareButton,
+  LinkedinIcon,
 } from 'react-share';
 import styled, { css } from 'styled-components';
 import Typography from '@material-ui/core/Typography';
@@ -397,6 +399,9 @@ class Blog extends Component {
                           <FacebookShareButton url={posts.link}>
                             <FacebookIcon size={32} round={true} />
                           </FacebookShareButton>
+                          <LinkedinShareButton url={posts.link}>
+                            <LinkedinIcon size={32} round={true} />
+                          </LinkedinShareButton>
                         </SocialButtons>
                         <BlogFooter>
                           <FlexBox>

--- a/src/components/Settings/ShareOnSocialMedia.js
+++ b/src/components/Settings/ShareOnSocialMedia.js
@@ -6,10 +6,12 @@ import {
   LinkedinShareButton as _LinkedinShareButton,
   TwitterShareButton as _TwitterShareButton,
   WhatsappShareButton as _WhatsappShareButton,
+  TelegramShareButton as _TelegramShareButton,
   FacebookIcon,
   TwitterIcon,
   LinkedinIcon,
   WhatsappIcon,
+  TelegramIcon,
 } from 'react-share';
 import styled, { css } from 'styled-components';
 
@@ -56,6 +58,10 @@ const WhatsappShareButton = styled(_WhatsappShareButton)`
   ${commonIconStyle};
 `;
 
+const TelegramShareButton = styled(_TelegramShareButton)`
+  ${commonIconStyle};
+`;
+
 const ShareOnSocialMedia = () => {
   const shareUrl = 'https://susi.ai';
   const title = 'Lets chat with SUSI.AI, the open source personal assistant';
@@ -94,6 +100,14 @@ const ShareOnSocialMedia = () => {
             </div>
             <TextContainer>Whatsapp</TextContainer>
           </WhatsappShareButton>
+        </IconButton>
+        <IconButton>
+          <TelegramShareButton url={shareUrl} title={title}>
+            <div>
+              <TelegramIcon size={42} />
+            </div>
+            <TextContainer>Telegram</TextContainer>
+          </TelegramShareButton>
         </IconButton>
       </ShareIconContainer>
     </React.Fragment>


### PR DESCRIPTION
Fixes #3159 

Changes: 
- Added sharing to LinkedIn within the blog page for posts about SUSI. LinkedIn is a popular method to share articles which could prove useful for users of susi.ai.
- Added Telegram as a source within settings to share via Social Media. Telegram is quite popular like WhatsApp across the world and could also be a viable option.

Demo Link: https://pr-3160-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
<img width="934" alt="Screen Shot 2019-12-27 at 1 58 52 PM" src="https://user-images.githubusercontent.com/44630385/71534070-0667a680-28b1-11ea-9573-9ad209808deb.png">
<img width="736" alt="Screen Shot 2019-12-27 at 1 57 16 PM" src="https://user-images.githubusercontent.com/44630385/71534082-1ed7c100-28b1-11ea-9a52-1434d2fe186a.png">
